### PR TITLE
Fix incorrect class test

### DIFF
--- a/inst/tests/test_pdata.frame_extract_class_est_mod.R
+++ b/inst/tests/test_pdata.frame_extract_class_est_mod.R
@@ -27,13 +27,13 @@ nrow(pGrunfeld[pGrunfeld$inv == 317.60, ])  # operation works on pdata.frame as 
 mod <- plm(inv ~ value + capital, data=pGrunfeld, model = "pooling")
 class(mod$model) # 'pseries' appeared twice before rev. 242
 if (!all(class(mod$model$inv) == c("pseries", "numeric"))) stop("wrong classes (or too few/many")
-if (!(length(class(mod$model$inv)) == 2 && class(mod$model$inv) == c("pseries", "numeric"))) warning("class(es) are wrong!")
+if (!(length(class(mod$model$inv)) == 2 && identical(class(mod$model$inv), c("pseries", "numeric")))) warning("class(es) are wrong!")
 
 
 df <- as.data.frame(mod$model)
 class(df)
 class(df$inv) # 'pseries' apperead two before rev. 242
-if (!(length(class(df$inv)) == 2 && class(df$inv) == c("pseries", "numeric"))) warning("class(es) are wrong!")
+if (!(length(class(df$inv)) == 2 && identical(class(df$inv), c("pseries", "numeric")))) warning("class(es) are wrong!")
 
 
 


### PR DESCRIPTION
The current test silently looks at only class(.)[[1]].

We could also use `all(class(.) == .)` but I think `identical()` is probably more appropriate here.