### PR TITLE
improve arrange.pdata.frame method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(person(given = "Yves",      family = "Croissant",    role = c("aut"
              person(given = "Nina",      family = "Schoenfelder", role = "ctb"))
 Depends: R (>= 3.2.0)
 Imports: MASS, bdsmatrix, collapse (>= 1.8.9), zoo, nlme, sandwich, lattice, lmtest, maxLik, Rdpack, Formula, stats
-Suggests: AER, car, statmod, urca, pder, texreg, knitr, rmarkdown, fixest, lfe
+Suggests: AER, car, statmod, urca, pder, texreg, knitr, rmarkdown, fixest, lfe, dplyr
 Description: A set of estimators for models and (robust) covariance matrices, and tests for panel data
              econometrics, including within/fixed effects, random effects, between, first-difference, 
              nested random effects as well as instrumental-variable (IV) and Hausman-Taylor-style models,

--- a/R/tool_pdata.frame.R
+++ b/R/tool_pdata.frame.R
@@ -1527,10 +1527,11 @@ pmerge <- function(x, y, ...) {
 # test in test_pdata.frame_compliant.R
 #' @exportS3Method dplyr::arrange pdata.frame
 arrange.pdata.frame <- function(.data, ..., .by_group = FALSE, .locale = NULL) {
+  stopifnot(requireNamespace("dplyr"))
   # function signature of dplyr:::arrange.data.frame
   idx <- index(.data)
   ag.data <- NextMethod()
-  ag.idx <- arrange(idx, ..., .by_group = FALSE, .locale = NULL) # dispatches to arrange.pindex
+  ag.idx <- dplyr::arrange(idx, ..., .by_group = FALSE, .locale = NULL) # dispatches to arrange.pindex
   attr(ag.data, "index") <- ag.idx
   ag.data
 }


### PR DESCRIPTION
In order to pass R CMD check without a NOTE:

- Include `dplyr` in `DESCRIPTION/Suggests`.
- Make sure `dplyr` is available in `arrange.pdata.frame()`.
- Fully-qualified dplyr::arrange() call.