### PR TITLE
Correct likely bug in pdata.frame

### DIFF
--- a/R/tool_pdata.frame.R
+++ b/R/tool_pdata.frame.R
@@ -265,7 +265,7 @@ pdata.frame <- function(x, index = NULL, drop.index = FALSE, row.names = TRUE,
     # grouping variable, this should be the third element of the index
     # vector or any "group" named element of this vector
     group.name <- NULL
-    if (! is.null(names(index)) || length(index == 3L)){
+    if (! is.null(names(index)) || length(index) == 3L){
         if (! is.null(names(index))){
             grouppos <- match("group", names(index))
             if (! is.na(grouppos)){


### PR DESCRIPTION
Detected while stress-testing the new `lintr::length_test_linter()` (https://github.com/r-lib/lintr/pull/2124).

I lack enough context about this function to offer a regression test, but it should be possible to do so by supplying something with `length(index) != 2`, then the `group.name` might populate incorrectly.