### PR TITLE
Fix mistaken all.equal() checks

### DIFF
--- a/inst/tests/test_fixef_comp_lm_plm.R
+++ b/inst/tests/test_fixef_comp_lm_plm.R
@@ -190,13 +190,13 @@ if(!isTRUE(all.equal(fixef_lm_tw_time_dfirst_u,  as.numeric(fixef_plm_tw_time_df
 # ## balanced
 plm_fw_tw_ind_level  <- fixef(plm_fe_tw, type = "level", effect = "individual")
 plm_fw_tw_time_level <- fixef(plm_fe_tw, type = "level", effect = "time")
-if(isTRUE(!all.equal(plm_fw_tw_ind_level[1], plm_fw_tw_time_level[1], check.attributes = FALSE))) {
+if(!isTRUE(all.equal(plm_fw_tw_ind_level[1], plm_fw_tw_time_level[1], check.attributes = FALSE))) {
   stop("two-ways balanced levels: first components of individual and time effect in levels are not equal")
 }
 ## unbalanced
 plm_fw_tw_ind_level_u  <- fixef(plm_fe_tw_u, type = "level", effect = "individual")
 plm_fw_tw_time_level_u <- fixef(plm_fe_tw_u, type = "level", effect = "time")
-if(isTRUE(!all.equal(plm_fw_tw_ind_level_u[1], plm_fw_tw_time_level_u[1], check.attributes = FALSE))) {
+if(!isTRUE(all.equal(plm_fw_tw_ind_level_u[1], plm_fw_tw_time_level_u[1], check.attributes = FALSE))) {
   stop("two-ways unbalanced levels: first components of individual and time effect in levels are not equal")
 }
 

--- a/inst/tests/test_model.frame.R
+++ b/inst/tests/test_model.frame.R
@@ -66,7 +66,7 @@ if(!all(plm_fe_NA_dep_var$coefficients == plm_fe_NA_dep_var2$coefficients)) stop
 
 # model.frames in plm_objects are the same
 if(!all(plm_fe_NA_dep_var$model == plm_fe_NA_dep_var2$model)) stop("model.frames diverge")
-if(!all.equal(plm_fe_NA_dep_var$model, plm_fe_NA_dep_var2$model, check.attributes = FALSE)) stop("model.frames diverge")
+if(!isTRUE(all.equal(plm_fe_NA_dep_var$model, plm_fe_NA_dep_var2$model, check.attributes = FALSE))) stop("model.frames diverge")
 #compare::compare(as.data.frame(plm_fe_NA_dep_var$model), as.data.frame(plm_fe_NA_dep_var2$model), ignoreAttrs = TRUE) # TRUE
 
 
@@ -80,7 +80,7 @@ if (!all(plm_fe_NA_dep_var_more$coefficients == plm_fe_NA_dep_var_more2$coeffici
 
 # model.frame in plm_object is same
 if (!all(plm_fe_NA_dep_var_more$model == plm_fe_NA_dep_var_more2$model)) stop("model.frames diverge")
-if (!all.equal(plm_fe_NA_dep_var_more$model, plm_fe_NA_dep_var_more2$model, check.attributes = FALSE)) stop("model.frames diverge")
+if (!isTRUE(all.equal(plm_fe_NA_dep_var_more$model, plm_fe_NA_dep_var_more2$model, check.attributes = FALSE))) stop("model.frames diverge")
 #compare::compare(as.data.frame(plm_fe_NA_dep_var_more$model), as.data.frame(plm_fe_NA_dep_var_more2$model), ignoreAttrs = TRUE) # TRUE
 
 
@@ -93,7 +93,7 @@ if (!all(plm_fe_NA_dep_var_tw$coefficients == plm_fe_NA_dep_var_tw2$coefficients
 
 # model.frame in plm_object is same
 if (!all(plm_fe_NA_dep_var_tw$model == plm_fe_NA_dep_var_tw$model)) stop("model.frames diverge")
-if (!all.equal(plm_fe_NA_dep_var_tw$model, plm_fe_NA_dep_var_tw2$model, check.attributes = FALSE)) stop("model.frames diverge")
+if (!isTRUE(all.equal(plm_fe_NA_dep_var_tw$model, plm_fe_NA_dep_var_tw2$model, check.attributes = FALSE))) stop("model.frames diverge")
 #compare::compare(as.data.frame(plm_fe_NA_dep_var_tw$model), as.data.frame(plm_fe_NA_dep_var_tw2$model), ignoreAttrs = TRUE) # TRUE
 
 
@@ -109,7 +109,7 @@ if (!all(plm_re_NA_dep_var$coefficients == plm_re_NA_dep_var2$coefficients)) sto
 
 # model.frames in plm_objects are the same
 if (!all(plm_re_NA_dep_var$model == plm_re_NA_dep_var2$model)) stop("model.frames diverge")
-if (!all.equal(plm_re_NA_dep_var$model, plm_re_NA_dep_var2$model, check.attributes = FALSE)) stop("model.frames diverge")
+if (!isTRUE(all.equal(plm_re_NA_dep_var$model, plm_re_NA_dep_var2$model, check.attributes = FALSE))) stop("model.frames diverge")
 #compare::compare(as.data.frame(plm_re_NA_dep_var$model), as.data.frame(plm_re_NA_dep_var2$model), ignoreAttrs = TRUE) # TRUE
 
 
@@ -123,7 +123,7 @@ if (!all(plm_re_NA_dep_var_more$coefficients == plm_re_NA_dep_var_more2$coeffici
 
 # model.frame in plm_object is same
 if (!all(plm_re_NA_dep_var_more$model == plm_re_NA_dep_var_more2$model)) stop("model.frames diverge")
-if (!all.equal(plm_re_NA_dep_var_more$model, plm_re_NA_dep_var_more2$model, check.attributes = FALSE)) stop("model.frames diverge")
+if (!isTRUE(all.equal(plm_re_NA_dep_var_more$model, plm_re_NA_dep_var_more2$model, check.attributes = FALSE))) stop("model.frames diverge")
 #compare::compare(as.data.frame(plm_re_NA_dep_var_more$model), as.data.frame(plm_re_NA_dep_var_more2$model), ignoreAttrs = TRUE) # TRUE
 
 


### PR DESCRIPTION
Discovered through robustness checks of the corresponding new `lintr::all_equal_linter()`:

https://github.com/r-lib/lintr/pull/2885